### PR TITLE
Update manifold based on feedback

### DIFF
--- a/models/memory/CaffDRAM/Controller.h
+++ b/models/memory/CaffDRAM/Controller.h
@@ -36,8 +36,8 @@ public:
 	template<typename T>
 	void handle_request(int, uarch::NetworkPacket* pkt);
 
-        void print_config(std::ostream&);
-        void print_stats(std::ostream&);
+    void print_config(std::ostream&);
+    void print_stats(std::ostream&);
 
 	static void Set_msg_types(int mem, int credit)
 	{

--- a/models/processor/spx/core.cc
+++ b/models/processor/spx/core.cc
@@ -128,6 +128,13 @@ void spx_core_t::reset_interval_stats()
     pipeline->stats.interval.uop_count = 0;
 }
 
+void spx_core_t::print_stats(std::ostream& out)
+{
+    out << "************ SPX Core " << core_id << " [node " << node_id << "] stats *************" << endl;
+    out << "  Total clock cycles: " << (double)clock_cycle/1e6 << "M" << endl;
+    out << "  avgIPC = " << (double)pipeline->stats.uop_count / (double) clock_cycle << endl; }
+
+
 void spx_core_t::handle_cache_response(int temp, cache_request_t *cache_request)
 {
     pipeline->handle_cache_response(temp,cache_request);

--- a/models/processor/spx/core.cc
+++ b/models/processor/spx/core.cc
@@ -102,6 +102,11 @@ void spx_core_t::tick()
     // This will periodically print the stats to show the progress of simulation -- for debugging
     print_stats(100000, stdout);
 #endif
+
+    if (get_qsim_osd_state() == QSIM_OSD_TERMINATED) {
+        fprintf(stdout, "SPX core %d out of insn", core_id);
+        manifold::kernel::Manifold::Terminate(); 
+    }
 }
 
 void spx_core_t::print_stats(uint64_t sampling_period, FILE *LogFile)

--- a/models/processor/spx/core.h
+++ b/models/processor/spx/core.h
@@ -38,6 +38,9 @@ public:
     void turn_on();
     void turn_off();
 
+//    void print_config(std::ostream&);
+    void print_stats(std::ostream&);
+
     void send_qsim_proxy_request();
 
     int node_id; // manifold node ID

--- a/simulator/smp/QsimProxy/smp_l1l2.cc
+++ b/simulator/smp/QsimProxy/smp_l1l2.cc
@@ -80,13 +80,13 @@ int main(int argc, char** argv)
     Manifold::Run();
 
 
-    sysBuilder.print_stats();
+    sysBuilder.print_stats(cerr);
 
 
 #ifdef REDIRECT_COUT
     std::cout.rdbuf(cout_sbuf);
 #endif
 
-    Manifold :: Finalize();
+    Manifold::Finalize();
 }
 

--- a/simulator/smp/QsimProxy/smp_llp.cc
+++ b/simulator/smp/QsimProxy/smp_llp.cc
@@ -90,13 +90,13 @@ int main(int argc, char** argv)
     Manifold::Run();
 
 
-    sysBuilder.print_stats();
+    sysBuilder.print_stats(cerr);
 
 
 #ifdef REDIRECT_COUT
     std::cout.rdbuf(cout_sbuf);
 #endif
 
-    Manifold :: Finalize();
+    Manifold::Finalize();
 }
 

--- a/simulator/smp/common/proc_builder.cc
+++ b/simulator/smp/common/proc_builder.cc
@@ -565,3 +565,13 @@ void Spx_builder :: print_config(std::ostream& out)
     out << "  config file: " << m_CONFIG_FILE << endl;
 }
 
+void Spx_builder :: print_stats(std::ostream& out)
+{
+    for(map<int,int>::iterator it = m_proc_id_cid_map.begin(); it != m_proc_id_cid_map.end(); ++it) {
+        int cid = (*it).second;
+	    spx_core_t* proc = manifold::kernel::Component :: GetComponent<spx_core_t>(cid);
+	    if(proc) {
+	        proc->print_stats(out);
+	    }
+    }
+}

--- a/simulator/smp/common/proc_builder.h
+++ b/simulator/smp/common/proc_builder.h
@@ -195,7 +195,7 @@ public:
     void connect_proc_qsim_proxy(QsimBuilder* qsim_builder);
 
     void print_config(std::ostream&);
-    //void print_stats(std::ostream&);
+    void print_stats(std::ostream&);
 
 private:
     Qsim::OSDomain* m_qsim_osd;

--- a/simulator/smp/common/sysBuilder_llp.cc
+++ b/simulator/smp/common/sysBuilder_llp.cc
@@ -664,13 +664,13 @@ void SysBuilder_llp :: print_config(ostream& out)
 
 //====================================================================
 //====================================================================
-void SysBuilder_llp :: print_stats()
+void SysBuilder_llp :: print_stats(ostream& out)
 {
-    m_proc_builder->print_stats(cout);
-    m_cache_builder->print_stats(cout);
-    m_mc_builder->print_stats(cout);
-    m_network_builder->print_stats(cout);
+    m_proc_builder->print_stats(out);
+    m_cache_builder->print_stats(out);
+    m_mc_builder->print_stats(out);
+    m_network_builder->print_stats(out);
 
-    Manifold :: print_stats(cout);
+    Manifold::print_stats(out);
 }
 

--- a/simulator/smp/common/sysBuilder_llp.h
+++ b/simulator/smp/common/sysBuilder_llp.h
@@ -40,7 +40,7 @@ public:
 
     void pre_simulation();
     void print_config(std::ostream& out);
-    void print_stats();
+    void print_stats(std::ostream& out);
 
     libconfig::Config m_config;
 


### PR DESCRIPTION
The patches address the following problems.
1, per-core manifold report is generated through cerr (cout somehow be captured by qsim and cannot be used)

2, manifold simulation terminates when qsim encounters app_end. 
