### PR TITLE
Manifold Openmpi multithread hotfix

### DIFF
--- a/models/processor/spx/core.cc
+++ b/models/processor/spx/core.cc
@@ -160,8 +160,10 @@ void spx_core_t::send_qsim_proxy_request()
 void spx_core_t::handle_qsim_response(int temp, qsim_proxy_request_t *qsim_proxy_request)
 {
     assert(qsim_proxy_request->get_core_id() == core_id);
-    assert(qsim_proxy_request_sent);
-    qsim_proxy_request_sent = false;
+    if (qsim_proxy_request->is_extended() == false) {
+        assert(qsim_proxy_request_sent);
+        qsim_proxy_request_sent = false;
+    }
 
     /* qsim_proxy_request is deleted here */
     qsim_proxy->handle_qsim_response(qsim_proxy_request);

--- a/models/processor/spx/qsim-proxy.cc
+++ b/models/processor/spx/qsim-proxy.cc
@@ -11,7 +11,7 @@ spx_qsim_proxy_t::spx_qsim_proxy_t(pipeline_t *Pipeline) :
     pipeline(Pipeline)
 {
     /* Reserve fixed queue length. */
-    queue.reserve(SPX_QSIM_PROXY_QUEUE_SIZE);
+    queue.reserve(QSIM_PROXY_QUEUE_SIZE);
     queue.clear();
 }
 
@@ -25,10 +25,9 @@ void spx_qsim_proxy_t::handle_qsim_response(qsim_proxy_request_t *QsimProxyReque
 #ifdef DEBUG_NEW_QSIM_1
     std::cerr << "******************" << std::endl << std::flush;
     std::cerr << std::dec << pipeline->core->core_id << " recv: " << QsimProxyRequest->get_queue_size() << std::endl << std::flush;
+    std::vector<Qsim::QueueItem>::size_type sz = queue.size(); 
     //QsimProxyRequest->dump_queue();
 #endif
-
-    int sz = queue.size(); 
     QsimProxyRequest->append_to(queue);
 #ifdef DEBUG_NEW_QSIM_1
     std::cerr << "copied: " << queue.size() - sz << std::endl << std::flush;

--- a/models/processor/spx/qsim-proxy.h
+++ b/models/processor/spx/qsim-proxy.h
@@ -7,70 +7,87 @@
 
 /* Refer to ../../qsim/proxy/proxy.h:QSIM_PROXY_QUEUE_SIZE */
 //#define SPX_QSIM_PROXY_QUEUE_SIZE 256
-#define SPX_QSIM_PROXY_QUEUE_SIZE 5000
+// The QSIM_* Macros should be identical to those in qsim/proxy/proxy.h
 
+#define QSIM_RUN_GRANULARITY   200
+#define QSIM_OVERHEAD   0.2
+#define QSIM_PROXY_QUEUE_SIZE (int)(5 * QSIM_RUN_GRANULARITY * (1 + QSIM_OVERHEAD))
 //#define DEBUG_NEW_QSIM 1
 //#define DEBUG_NEW_QSIM_1 1
 
 namespace manifold {
 namespace spx {
 
+
 class qsim_proxy_request_t
 {
 public:
     qsim_proxy_request_t() {}
-    qsim_proxy_request_t(int CoreID, int PortID) : core_id(CoreID),
+    qsim_proxy_request_t(int CoreID, int PortID, bool ex = false) : core_id(CoreID),
                                                    port_id(PortID),
+                                                   extended (ex),
                                                    num_queue_items(0) {}
     ~qsim_proxy_request_t() {}
 
     int get_core_id() const { return core_id; }
     int get_port_id() const { return port_id; }
+    bool is_extended() const { return extended; }
     Qsim::QueueItem get_queue_item(unsigned idx) const { return queue[idx]; }
-    void push_back(Qsim::QueueItem queue_item) { queue.push_back(queue_item); }
+    void push_back(Qsim::QueueItem queue_item) { queue[num_queue_items++] = queue_item; }
     void reset() { num_queue_items = 0; }
-    unsigned get_queue_size() const { return queue.size(); }
+    unsigned get_queue_size() const { return num_queue_items; }
     void append_to (std::vector<Qsim::QueueItem> &q) { 
 #ifdef DEBUG_NEW_QSIM
-        std::cerr << "in append_to -> q: " << q.size() << " queue: " << queue.size() << std::endl << std::flush; 
+        std::cerr << "in append_to -> q: " << q.size() << " queue: " << get_queue_size() << std::endl << std::flush; 
 #endif
-        q.insert(q.end(), queue.begin(), queue.end()); 
+        q.insert(q.end(), std::begin(queue), std::begin(queue) + get_queue_size()); 
 #ifdef DEBUG_NEW_QSIM
-        std::cerr << "in append_to[af] -> q: " << q.size() << " queue: " << queue.size() << std::endl << std::flush; 
+        std::cerr << "in append_to[af] -> q: " << q.size() << " queue: " << get_queue_size() << std::endl << std::flush; 
 #endif
     }
-    void dump_queue () {
-        for(std::vector<Qsim::QueueItem>::iterator it = queue.begin(); it != queue.end(); it++) {
-           Qsim::QueueItem qi = *it;
-           switch (qi.cb_type) {
-               case Qsim::QueueItem::INST:
-                   std::cerr << "(core " << std::dec << qi.id << " ) | INST" << std::endl << std::flush;
-                   break;
-               case Qsim::QueueItem::MEM:
-                   std::cerr << "(core " << std::dec << qi.id << " ) | MEM" << std::endl << std::flush;
-                   break;
-               case Qsim::QueueItem::REG:
-                   std::cerr << "(core " << std::dec << qi.id << " ) | REG" << std::endl << std::flush;
-                   break;
-               case Qsim::QueueItem::IDLE:
-                   std::cerr << "(core " << std::dec << qi.id << " ) | IDLE" << std::endl << std::flush;
-                   break;
-               case Qsim::QueueItem::TERMINATED:
-                   std::cerr << "(core " << std::dec << qi.id << " ) | TERMINATED" << std::endl << std::flush;
-                   break;
-                default:
-                   std::cerr << " (core " << std::dec << qi.id << ") | Wrong Type!" << std::endl << std::flush;
-           } 
-        } 
-    }
+    //void dump_queue () {
+        //for(std::vector<Qsim::QueueItem>::iterator it = queue.begin(); it != queue.end(); it++) {
+           //Qsim::QueueItem qi = *it;
+           //switch (qi.cb_type) {
+               //case Qsim::QueueItem::INST:
+                   //std::cerr << "(core " << std::dec << qi.id << " ) | INST" << std::endl << std::flush;
+                   //break;
+               //case Qsim::QueueItem::MEM:
+                   //std::cerr << "(core " << std::dec << qi.id << " ) | MEM" << std::endl << std::flush;
+                   //break;
+               //case Qsim::QueueItem::REG:
+                   //std::cerr << "(core " << std::dec << qi.id << " ) | REG" << std::endl << std::flush;
+                   //break;
+               //case Qsim::QueueItem::IDLE:
+                   //std::cerr << "(core " << std::dec << qi.id << " ) | IDLE" << std::endl << std::flush;
+                   //break;
+               //case Qsim::QueueItem::TERMINATED:
+                   //std::cerr << "(core " << std::dec << qi.id << " ) | TERMINATED" << std::endl << std::flush;
+                   //break;
+                //default:
+                   //std::cerr << " (core " << std::dec << qi.id << ") | Wrong Type!" << std::endl << std::flush;
+           //} 
+        //} 
+    //}
+
+    //qsim_proxy_request_t operator=(const qsim_proxy_request_t _)
+    //{
+        //core_id = _.core_id;
+        //port_id = _.port_id;
+        //queue = _.queue;
+        //num_queue_items = _.num_queue_items;
+
+        //return *this;
+    //}
 
 private:
     int core_id;
     int port_id;
-    std::vector<Qsim::QueueItem> queue;
+    Qsim::QueueItem queue[QSIM_PROXY_QUEUE_SIZE];
+    //std::vector<Qsim::QueueItem> queue;
     unsigned num_queue_items;
+    bool extended;
 };
-
 
 
 class spx_qsim_proxy_t {


### PR DESCRIPTION
fix the bug with multiple NPs, as manifold Send() does not support data with dynamic length (i.e. std::vector).

Details: previous version (V1.0) uses std::vector in qsim_proxy_request which would cause memory seg fault, as Manifold Send() uses sizeof to measure the length of the std::vector (which is wrong). In the future release, the Send() with dynamic length is expected to support for simulation speed. 
