### PR TITLE
Update manifold license & readme

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,25 @@
+Copyright (c) <2016>, <Computer Architecture and Systems Laboratory, Georgia
+Institute of Technology>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Georgia Institute of Technology nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDER BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# manifold[![Build Status](https://travis-ci.org/gtcasl/manifold.svg?branch=master)](https://travis-ci.org/gtcasl/manifold)
+manifold[![Build Status](https://travis-ci.org/gtcasl/manifold.svg?branch=master)](https://travis-ci.org/gtcasl/manifold)
+=============
 A Parallel Simulation Framework For Multicore Systems
+
+
+**Installation Instructions**
+
+If you are on Ubuntu (>= 14.04), just run setup.sh script in the root directory 
+after QSim is installed. This will link the manifold to the QSim library specifi
+ed by $QSIM_PREFIX variable, download multi-thread benchmarks supported by manif
+old, and build the manifold components and simulators.
+
+Users under other Linux distributions, please consult instructions in [manifold document](http://manifold.gatech.edu/documentation).


### PR DESCRIPTION
A separate BSD-compatible license file is added to the repo. Also, update the readme to include an installation instruction.
